### PR TITLE
Fix concurrency warnings for core dependencies

### DIFF
--- a/Modules/Core/CoreKit/Sources/AppConfiguration.swift
+++ b/Modules/Core/CoreKit/Sources/AppConfiguration.swift
@@ -2,7 +2,7 @@ import Foundation
 import Dependencies
 import Logging
 
-public final class AppConfiguration {
+public struct AppConfiguration: Sendable {
     public enum Environment: String {
         case debug
         case release
@@ -18,16 +18,19 @@ public final class AppConfiguration {
         self.logger = logger
     }
 
+    @MainActor
     public func register() {
         AppConfigurationStorage.shared = self
         logger.info("Registering dependencies for environment: \(environment.rawValue)")
     }
 
+    @MainActor
     public static var current: AppConfiguration {
         AppConfigurationStorage.shared
     }
 }
 
+@MainActor
 private enum AppConfigurationStorage {
     static var shared = AppConfiguration()
 }

--- a/Modules/Core/CoreKit/Sources/NetworkingClient.swift
+++ b/Modules/Core/CoreKit/Sources/NetworkingClient.swift
@@ -2,8 +2,8 @@ import Foundation
 import Dependencies
 import Alamofire
 
-public struct NetworkingClient {
-    public var getJSON: @Sendable (_ url: URL) async throws -> Data
+public struct NetworkingClient: Sendable {
+    public let getJSON: @Sendable (_ url: URL) async throws -> Data
 
     public init(getJSON: @escaping @Sendable (_ url: URL) async throws -> Data) {
         self.getJSON = getJSON

--- a/Modules/Core/CoreKit/Tests/CoreKitTests.swift
+++ b/Modules/Core/CoreKit/Tests/CoreKitTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import MacroTesting
 @testable import CoreKit
 
+@MainActor
 final class CoreKitTests: XCTestCase {
     func testConfigurationRegistersDependencies() {
         let config = AppConfiguration(environment: .testing)


### PR DESCRIPTION
## Summary
- make `AppConfiguration` sendable and isolate its shared storage on the main actor
- mark the core configuration test as main-actor isolated to match the new API
- ensure `NetworkingClient` is sendable by using an immutable sendable closure

## Testing
- `swift test` *(fails: unable to clone remote dependencies because outbound network access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e456a4acc4832494fc00aa54150e49