### PR TITLE
Fix dependency keys access main actor configuration

### DIFF
--- a/Modules/Core/CoreKit/Sources/AppConfiguration.swift
+++ b/Modules/Core/CoreKit/Sources/AppConfiguration.swift
@@ -36,11 +36,15 @@ private enum AppConfigurationStorage {
 }
 
 private enum LoggerKey: DependencyKey {
-    static let liveValue: Logger = AppConfigurationStorage.shared.logger
+    static var liveValue: Logger {
+        MainActor.assumeIsolated { AppConfigurationStorage.shared.logger }
+    }
 }
 
 private enum AppConfigurationKey: DependencyKey {
-    static let liveValue: AppConfiguration = AppConfigurationStorage.shared
+    static var liveValue: AppConfiguration {
+        MainActor.assumeIsolated { AppConfigurationStorage.shared }
+    }
 }
 
 public extension DependencyValues {


### PR DESCRIPTION
## Summary
- avoid accessing main-actor isolated configuration storage from nonisolated dependency defaults by using MainActor.assumeIsolated

## Testing
- `swift test` *(fails: network access to remote dependencies is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4592ab6f0832483422e9829e657ff