### PR TITLE
Refactor Clean list interactor concurrency

### DIFF
--- a/Modules/Features/CleanFeature/Sources/CleanListContracts.swift
+++ b/Modules/Features/CleanFeature/Sources/CleanListContracts.swift
@@ -2,20 +2,22 @@ import Foundation
 import Dependencies
 import CoreKit
 
-public protocol CleanListBusinessLogic {
-    func load()
-    func refresh()
+public protocol CleanListBusinessLogic: AnyObject {
+    func load(request: CleanListModels.Request) async
+    func refresh(request: CleanListModels.Request) async
 }
 
+@MainActor
 public protocol CleanListPresentationLogic: AnyObject {
     func present(response: CleanListModels.Response)
 }
 
+@MainActor
 public protocol CleanListDisplayLogic: AnyObject {
     func display(viewModel: [CleanListModels.ViewModel])
 }
 
-public protocol CleanListWorkerProtocol {
+public protocol CleanListWorkerProtocol: Sendable {
     func fetchItems() async throws -> [CleanListModels.Item]
 }
 
@@ -45,3 +47,5 @@ public struct CleanListWorker: CleanListWorkerProtocol {
         let items: [ItemDTO]
     }
 }
+
+extension CleanListWorker: @unchecked Sendable {}

--- a/Modules/Features/CleanFeature/Sources/CleanListInteractor.swift
+++ b/Modules/Features/CleanFeature/Sources/CleanListInteractor.swift
@@ -12,31 +12,21 @@ public final class CleanListInteractor: CleanListBusinessLogic {
         self.worker = worker
     }
 
-    public func load() {
-        scheduleLoad()
+    public func load(request: CleanListModels.Request) async {
+        await performLoad()
     }
 
-    public func refresh() {
-        scheduleLoad()
+    public func refresh(request: CleanListModels.Request) async {
+        await performLoad()
     }
 
-    private func scheduleLoad() {
-        let worker = self.worker
-        let logger = self.logger
-
-        Task.detached(priority: nil) { [worker, logger, weak self] in
-            guard let self else { return }
-            do {
-                let items = try await worker.fetchItems()
-                await MainActor.run {
-                    self.presenter.present(response: .init(items: items))
-                }
-            } catch {
-                logger.error("CleanListInteractor error: \(error.localizedDescription)")
-                await MainActor.run {
-                    self.presenter.present(response: .init(items: []))
-                }
-            }
+    private func performLoad() async {
+        do {
+            let items = try await worker.fetchItems()
+            await presenter.present(response: .init(items: items))
+        } catch {
+            logger.error("CleanListInteractor error: \(error.localizedDescription)")
+            await presenter.present(response: .init(items: []))
         }
     }
 }

--- a/Modules/Features/CleanFeature/Sources/CleanListPresenter.swift
+++ b/Modules/Features/CleanFeature/Sources/CleanListPresenter.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+@MainActor
 public final class CleanListPresenter: CleanListPresentationLogic {
     private weak var view: CleanListDisplayLogic?
 

--- a/Modules/Features/CleanFeature/Sources/CleanListView.swift
+++ b/Modules/Features/CleanFeature/Sources/CleanListView.swift
@@ -26,13 +26,13 @@ public struct CleanListView: View {
                 if controller.items.isEmpty {
                     LottieLoopView(animationName: "Loading")
                         .frame(width: 120, height: 120)
-                        .task { controller.load() }
+                        .task { await controller.load() }
                 }
             }
             .navigationTitle("Clean Swift")
             .toolbar {
                 Button("Refresh") {
-                    controller.refresh()
+                    Task { await controller.refresh() }
                 }
             }
         }
@@ -46,12 +46,12 @@ final class CleanListController: ObservableObject, CleanListDisplayLogic {
     private lazy var presenter = CleanListPresenter(view: self)
     private lazy var interactor = CleanListInteractor(presenter: presenter)
 
-    func load() {
-        interactor.load()
+    func load() async {
+        await interactor.load(request: .init())
     }
 
-    func refresh() {
-        interactor.refresh()
+    func refresh() async {
+        await interactor.refresh(request: .init())
     }
 
     func display(viewModel: [CleanListModels.ViewModel]) {

--- a/Modules/Features/CleanFeature/Tests/CleanListInteractorTests.swift
+++ b/Modules/Features/CleanFeature/Tests/CleanListInteractorTests.swift
@@ -7,8 +7,7 @@ final class CleanListInteractorTests: XCTestCase {
         let worker = WorkerStub(items: [.init(id: UUID(), title: "Hello", subtitle: "World")])
         let interactor = CleanListInteractor(presenter: presenter, worker: worker)
 
-        interactor.load()
-        try? await Task.sleep(nanoseconds: 50_000_000)
+        await interactor.load(request: .init())
 
         XCTAssertEqual(presenter.responses.count, 1)
         XCTAssertEqual(presenter.responses.first?.items.count, 1)

--- a/Tests/{{ProjectName}}Tests/{{ProjectName}}Tests.swift
+++ b/Tests/{{ProjectName}}Tests/{{ProjectName}}Tests.swift
@@ -15,8 +15,7 @@ final class {{ProjectName}}Tests: XCTestCase {
     func testCleanInteractor() async {
         let presenter = SpyPresenter()
         let interactor = CleanListInteractor(presenter: presenter, worker: MockWorker())
-        interactor.load()
-        try? await Task.sleep(nanoseconds: 50_000_000)
+        await interactor.load(request: .init())
         XCTAssertEqual(presenter.presentCalls.count, 1)
     }
 
@@ -28,6 +27,7 @@ final class {{ProjectName}}Tests: XCTestCase {
     }
 }
 
+@MainActor
 private final class SpyPresenter: CleanListPresentationLogic {
     var presentCalls: [CleanListModels.Response] = []
 


### PR DESCRIPTION
## Summary
- make the Clean list contracts async and main-actor isolate the presenter/display paths
- refactor the interactor to await worker results instead of spawning detached tasks
- update the SwiftUI controller and tests to call the async API directly

## Testing
- swift test *(fails: repository dependencies cannot be fetched in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e490262d64832498edc30362881141