### PR TITLE
Fix MVVM loader image request

### DIFF
--- a/Modules/Features/MVVMFeature/Sources/MVVMLoaderViewModel.swift
+++ b/Modules/Features/MVVMFeature/Sources/MVVMLoaderViewModel.swift
@@ -29,7 +29,7 @@ public final class MVVMLoaderViewModel {
         guard let url = imageURL else { return }
         imageState.isLoading = true
         do {
-            let response = try await pipeline.image(for: URLRequest(url: url))
+            let response = try await pipeline.image(for: ImageRequest(url: url))
             imageState.image = response.image
         } catch {
             logger.error("Image load failed: \(error.localizedDescription)")


### PR DESCRIPTION
## Summary
- update the MVVM loader view model to use Nuke's ImageRequest API when loading the image

## Testing
- `swift build` *(fails: network restrictions prevented cloning package dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e4949b98748324842eb23f53a48a4c