### PR TITLE
Add Alamofire dependency to MVVMFeature target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -49,7 +49,8 @@ let package = Package(
             name: "MVVMFeature",
             dependencies: [
                 "CoreKit",
-                .product(name: "Nuke", package: "Nuke")
+                .product(name: "Nuke", package: "Nuke"),
+                .product(name: "Alamofire", package: "Alamofire")
             ],
             path: "Modules/Features/MVVMFeature/Sources"
         ),


### PR DESCRIPTION
## Summary
- add the Alamofire product to the MVVMFeature target dependencies so the module can link against it

## Testing
- swift test *(fails: network access to clone dependencies is blocked in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e496e68fa08324921939bde2add531